### PR TITLE
Updated list.network.json For Go 1.6

### DIFF
--- a/layouts/_default/list.network.json
+++ b/layouts/_default/list.network.json
@@ -1,59 +1,59 @@
-{{ $nodes := slice }}
-{{ $stash := slice }}
-{{ range $taxonomy_term, $taxonomy := $.Site.Taxonomies }}
-	{{ if eq $taxonomy_term "links" }}
-		{{ with $.Site.GetPage (printf "/%s" $taxonomy_term) }}
-			{{ range $key, $value := $taxonomy }}
-				{{ if not (in $nodes $key)}}
-					{{ $nodes = $nodes | append $key }}
-					{{ range $value.Pages }}
-						{{ if not (in $nodes .File)}}
-							{{ $nodes = $nodes | append .File }}
-						{{ end }}
-					{{ end }}
-				{{ end }}
-			{{ end }}
-		{{ end }}
-	{{ end }}
-{{ end }}
-{{range .Site.RegularPages}}
-	{{ if not (in $nodes .File)}}
-		{{ $nodes = $nodes | append .File }}
-	{{ end }}
-{{end}}
+{{-  $nodes := slice  -}}
+{{-  $stash := slice  -}}
+{{-  range $taxonomy_term, $taxonomy := $.Site.Taxonomies  -}}
+	{{-  if eq $taxonomy_term "links"  -}}
+		{{-  with $.Site.GetPage (printf "/%s" $taxonomy_term)  -}}
+			{{-  range $key, $value := $taxonomy  -}}
+				{{-  if not (in $nodes $key) -}}
+					{{-  $nodes = $nodes | append $key  -}}
+					{{-  range $value.Pages  -}}
+						{{-  if not (in $nodes .File) -}}
+							{{-  $nodes = $nodes | append .File  -}}
+						{{-  end  -}}
+					{{-  end  -}}
+				{{-  end  -}}
+			{{-  end  -}}
+		{{-  end  -}}
+	{{-  end  -}}
+{{-  end  -}}
+{{- range .Site.RegularPages -}}
+	{{-  if not (in $nodes .File) -}}
+		{{-  $nodes = $nodes | append .File  -}}
+	{{-  end  -}}
+{{- end -}}
 {
 	"type": "NetworkGraph",
     "version": "",
     "revision": null,
-	"nodes": [{{ range $i, $node := $nodes }} {{ if not (in (delimit $stash ',') $node) }}
-		{{ if $i }}, {{ end }}{
-			"id": "{{ $node }}",
-			"label": {{ $nodepage := $.Site.GetPage (printf "/%s" $node) }} {{ if $nodepage }}"{{ $nodepage.Title }}" {{ else }} "" {{ end }},
+	"nodes": [{{-  range $i, $node := $nodes  -}} {{-  if not (in (delimit $stash ',') $node)  -}}
+		{{-  if $i  -}}, {{-  end  -}}{
+			"id": "{{-  $node  -}}",
+			"label": {{-  $nodepage := $.Site.GetPage (printf "/%s" $node)  -}} {{-  if $nodepage  -}}"{{-  $nodepage.Title  -}}" {{-  else  -}} "" {{-  end  -}},
 			"properties":{
-				"link": {{ $nodepage := $.Site.GetPage (printf "/%s" $node) }} {{ if $nodepage }}"{{ $nodepage.Permalink }}" {{ else }} "" {{ end }}
+				"link": {{-  $nodepage := $.Site.GetPage (printf "/%s" $node)  -}} {{-  if $nodepage  -}}"{{-  $nodepage.Permalink  -}}" {{-  else  -}} "" {{-  end  -}}
 			}
 		}
-		{{ $stash =  $stash | append $node }}{{ end }}{{ end }}],
+		{{-  $stash =  $stash | append $node  -}}{{-  end  -}}{{-  end  -}}],
 	"links": [
-		{{ range $taxonomy_term, $taxonomy := $.Site.Taxonomies }}
-			{{ if eq $taxonomy_term "links" }}
-				{{ with $.Site.GetPage (printf "/%s" $taxonomy_term) }}
-					{{ $keys := slice }}
-					{{ range $key, $value := $taxonomy }}
-						{{ $keys = $keys | append $key }}
-					{{ end }}
-					{{ $last := index $keys (sub (len $keys) 1) }}
-					{{ range $key, $value := $taxonomy }}
-							{{ range $i, $page := $value.Pages }}
-								{{if $i}},{{end}}{
-									"source": "{{ $page.File }}",
-									"target": "{{$key}}"
+		{{-  range $taxonomy_term, $taxonomy := $.Site.Taxonomies  -}}
+			{{-  if eq $taxonomy_term "links"  -}}
+				{{-  with $.Site.GetPage (printf "/%s" $taxonomy_term)  -}}
+					{{-  $keys := slice  -}}
+					{{-  range $key, $value := $taxonomy  -}}
+						{{-  $keys = $keys | append $key  -}}
+					{{-  end  -}}
+					{{-  $last := index $keys (sub (len $keys) 1)  -}}
+					{{-  range $key, $value := $taxonomy  -}}
+							{{-  range $i, $page := $value.Pages  -}}
+								{{- if $i -}},{{- end -}}{
+									"source": "{{-  $page.File  -}}",
+									"target": "{{- $key -}}"
 								}
-							{{ end }}{{ if ne $key $last }},{{end}}
-					{{ end }}
-				{{ end }}
-			{{ end }}
-		{{ end }}
+							{{-  end  -}}{{-  if ne $key $last  -}},{{- end -}}
+					{{-  end  -}}
+				{{-  end  -}}
+			{{-  end  -}}
+		{{-  end  -}}
 	]
 }
 


### PR DESCRIPTION
Found out that Go 1.6 introduces the ability to trim whitespace from either side of a Go tag by using a hyphen. Edited this json file to reflect that.

See the latest [Hugo documentation here](https://gohugo.io/templates/introduction/#whitespace).

Reference to #3 